### PR TITLE
Enabling multiple recipients

### DIFF
--- a/backlash/tracing/reporters/mail.py
+++ b/backlash/tracing/reporters/mail.py
@@ -21,7 +21,10 @@ class EmailReporter(object):
         self.smtp_use_tls = smtp_use_tls
 
         if isinstance(error_email, string_types):
-            error_email = [error_email]
+            if "," in error_email:
+                error_email = error_email.split(",")
+            else:
+                error_email = [error_email]
         self.error_email = error_email
 
         self.error_subject_prefix = error_subject_prefix

--- a/backlash/tracing/reporters/mail.py
+++ b/backlash/tracing/reporters/mail.py
@@ -21,10 +21,7 @@ class EmailReporter(object):
         self.smtp_use_tls = smtp_use_tls
 
         if isinstance(error_email, string_types):
-            if "," in error_email:
-                error_email = error_email.split(",")
-            else:
-                error_email = [error_email]
+            error_email = error_email.split(",")
         self.error_email = error_email
 
         self.error_subject_prefix = error_subject_prefix


### PR DESCRIPTION
Enabling multiple recipients, splitting the `error_email` field on the comma (`,`) character