### PR TITLE
fix sentry reporter

### DIFF
--- a/backlash/tbtools.py
+++ b/backlash/tbtools.py
@@ -195,6 +195,7 @@ class Traceback(object):
     def __init__(self, exc_type, exc_value, tb, context=None):
         self.exc_type = exc_type
         self.exc_value = exc_value
+        self.exc_info = (exc_type, exc_value, tb,)
         self.context = context
 
         if not isinstance(exc_type, str):

--- a/backlash/tracing/reporters/sentry.py
+++ b/backlash/tracing/reporters/sentry.py
@@ -33,7 +33,7 @@ class SentryReporter(object):
                                        stack=traceback.frames)
         else:
             # This is a real crash
-            self.client.captureException(data=data)
+            self.client.captureException(exc_info=traceback.exc_info, data=data)
 
 
 class RavenNotAvailable(Exception):


### PR DESCRIPTION
As described in https://github.com/TurboGears/tg2/issues/94

Sometimes we cannot access sys.exc_info(). TurboGears saves the original
exc_info() in the os.environ so that we can properly initialize the
Traceback object. I'm taking advantage of this information to specify
the exc_info attribute of the method captureException from the raven
lib. This way it won't need to access sys.exc_info().