### PR TITLE
Include license file in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 global-exclude *.pyc
 recursive-include backlash/statics *
+include LICENSE


### PR DESCRIPTION
Per the terms of the MIT license, it must be "included in all copies or substantial portions of the Software".