### PR TITLE
Handle incomplete input in the interactive console

### DIFF
--- a/backlash/console.py
+++ b/backlash/console.py
@@ -134,7 +134,9 @@ def _wrap_compiler(console):
     compile = console.compile
     def func(source, filename, symbol):
         code = compile(source, filename, symbol)
-        console.loader.register(code, source)
+        if code is not None:
+            # codeop returns None to signal that more input is needed
+            console.loader.register(code, source)
         return code
     console.compile = func
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -69,3 +69,11 @@ def test_exceptions_are_rendered_as_a_traceback(monkeypatch):
     assert '<div class="traceback">' in transcript
     assert '<pre>1/0</pre>' in transcript  # the offending console line
     assert '<blockquote>ZeroDivisionError: division by zero</blockquote>' in transcript
+
+
+def test_multi_line_input_is_buffered_until_complete(monkeypatch):
+    monkeypatch.setattr(sys, 'stdout', sys.stdout)
+    console = Console()
+    assert console.eval('if True:') == '>>> if True:\n'
+    assert console.eval('    x = 6*7') == '...     x = 6*7\n'
+    assert console.eval('x') == '>>> x\n<span class="number">42</span>'


### PR DESCRIPTION
Fixes #30. codeop returns None from compile to signal that more input is needed, but the wrapped compiler passed it straight to loader.register, which crashed on code.co_consts. Skipping registration for None lets the existing more/buffer logic in runsource handle multi-line input as intended.